### PR TITLE
fix: Remove dependency on build

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -5,7 +5,6 @@ on:
 jobs:
   auto-update-dependencies:
     name: Auto-Approve and enable Auto-Merge for all Dependabot PRs
-    needs: build
     runs-on: ubuntu-latest
     steps:
     - id: auto-approve-dependabot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Lint & build
   test:
-    name: Build
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
# What?
Remove dependency on build.

# Why?
There's no task called build!