### PR TITLE
chore: Checkout automerge repo before attempting to run an action

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -12,6 +12,11 @@ jobs:
       if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Checkout
+      uses: actions/checkout@master
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      with:
+        fetch-depth: 1
     - id: enable-automerge
       name: Enable Github Automerge
       if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'


### PR DESCRIPTION
# What?
Checkout the automerge repository before attempting to run the action.

# Why?
Until the action is checked out, it can't run!