### PR TITLE
Ignore dist by default

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -23,5 +23,5 @@ jobs:
       run: npm run build
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        file_pattern: dist/*
+        file_pattern: --force dist/*
         commit_message: "chore: 🛠 Rebuild action!"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+dist/


### PR DESCRIPTION
# Why?
Following #14, this is a fairly simple & reliable way of preventing accidental commits to `dist/*`, while preserving previous auto-rebuild behaviour.

# What?
- .gitignore `dist/*` by default (thanks for this @bdo!)
- instruct `stefanzweifel/git-auto-commit-action` to force add `dist/*` which supersedes the gitignore rule.

# Anything else?
This fixes #13 & closes #14.