### PR TITLE
feat: Migrate action to pull_request_target scope

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,23 +7,15 @@ on:
     types: [labeled]
 
 jobs:
-  auto-update-dependencies:
-    name: Auto-Approve and enable Auto-Merge for all Dependabot PRs
+  # Explicitly check-out & run a local version of this action.
+  # Note: This is *not* a recommended practice, and is only done here to dogfood the action.
+  # Please avoid running this action in a workflow which checks out code.
+  auto-merge-dependency-updates:
+    name: Enable auto-merge for Dependabot PRs
     runs-on: ubuntu-latest
-    
     # Specifically check the creator of the pull-request, not the actor.
     if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
-    
-    # Reference hmarr/auto-approve-action by commit SHA as it is an immutable reference to a
-    # known, "trusted" version of this 3rd party code.
-    - id: auto-approve-dependabot
-      uses: hmarr/auto-approve-action@bca9db08da72b576ae3273e776e7ccf3f0a36e12
-      with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
-        
-    # Note: This is *not* a recommended practice, and is only done here to dogfood the action.
-    # Please avoid running this action in a workflow which checks out code.
     - name: Checkout
       uses: actions/checkout@master
       with:
@@ -31,5 +23,20 @@ jobs:
     - id: enable-automerge
       name: Enable Github Automerge
       uses: ./
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  # Reference hmarr/auto-approve-action by commit SHA as it is an immutable reference to a
+  # known, "trusted" version of this 3rd party code.
+  # Note: This is a separate job to explicitly *not* check-out local code.
+  auto-approve-dependency-updates:
+    name: Approve dependabot PRs
+    runs-on: ubuntu-latest
+    needs: auto-merge-dependency-updates
+    # Specifically check the creator of the pull-request, not the actor.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
+    steps:
+    - id: auto-approve-dependabot
+      uses: hmarr/auto-approve-action@bca9db08da72b576ae3273e776e7ccf3f0a36e12
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,17 +1,29 @@
 name: Automatically Update Dependencies
+
+# `pull_request_target` grants access to secrets and runs in the scope of the *destination* branch.
+# Specifically we listen for the labelled event.
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   auto-update-dependencies:
     name: Auto-Approve and enable Auto-Merge for all Dependabot PRs
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    
+    # Specifically check the creator of the pull-request, not the actor.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
+    
+    # Reference hmarr/auto-approve-action by commit SHA as it is an immutable reference to a
+    # known, "trusted" version of this 3rd party code.
     - id: auto-approve-dependabot
-      uses: hmarr/auto-approve-action@v2.0.0
+      uses: hmarr/auto-approve-action@bca9db08da72b576ae3273e776e7ccf3f0a36e12
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
+        
+    # Note: This is *not* a recommended practice, and is only done here to dogfood the action.
+    # Please avoid running this action in a workflow which checks out code.
     - name: Checkout
       uses: actions/checkout@master
       with:

--- a/README.md
+++ b/README.md
@@ -12,23 +12,30 @@ Name: `alexwilson/enable-github-automerge-action`
 
 To speed up some of your workflows, this action allows you to automatically enable [Auto-Merge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request) in your Github pull-requests.  
 
-When enabled, Auto-Merge will merge pull-requests automatically _as soon as all requirements are met_ (approvals, passing tests).
+When enabled, auto-merge will merge pull-requests automatically _as soon as all requirements are met_ (i.e. approvals, passing tests).
 
 _You can use this, for example, to automatically merge Dependabot pull-requests_.
 
-This action pairs well with [`hmarr/auto-approve-action`](https://github.com/hmarr/auto-approve-action)
+This action pairs well with [`hmarr/auto-approve-action`](https://github.com/hmarr/auto-approve-action).
 
 ## 2) Usage
 
 Add as a step inside a GitHub workflow, e.g. `.github/workflows/auto-merge.yml`.  [You can see an example of this in this repository](./.github/workflows/auto-merge-dependabot.yml).
 
+> ⚠️  GitHub have [recently improved the security model of actions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) reducing the risk of unknown code accessing secrets, so we recommend running this in an isolated workflow within the `pull_request_target` scope, on a trusted event (e.g. `labeled`).
+
 ```yaml
 name: Auto-Merge
-on: pull_request
+on:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
-  build:
+  enable-auto-merge:
     runs-on: ubuntu-latest
+
+    # Specifically check that dependabot (or another trusted party) created this pull-request, and that it has been labelled correctly.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
     - uses: alexwilson/enable-github-automerge-action@main
       with:


### PR DESCRIPTION
# Why?
GitHub recently introduced a security update to actions which alters the scoping of permissions available to actions, to reduce the risk of untrusted 3rd party code being able to access repository secrets.

In https://github.com/alexwilson/frontend/pull/1518 & https://github.com/alexwilson/frontend/pull/1519 I migrated to the labelled event.

# What?
This migrates to the labelled event in the pull_request_target scope, and to make things easier to debug - checks for the original creator of the pull-request itself.

# Anything else?
fixes #18 