### PR TITLE
Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: 'Preferred merge method for automatic merges.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
# Why?
Fix #394 so that the action runs on node16 without producing the runtime warning.

# What?
Just update the node version to node16 given that github is already forcing it to do this.
