### PR TITLE
fix(ci): pin Release Please bootstrap-sha to the 2.0.0 commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "enable-github-automerge-action",
       "include-component-in-tag": false,
       "include-v-in-tag": false,
+      "bootstrap-sha": "56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
# Why?

Release Please was crashing while scanning git history. Without a hint, it walks every commit back from HEAD looking for the last release commit, and this repo has hundreds of pre-2.0.0 commits (years of Dependabot bumps). The backfill loop either hits the API rate limit or trips on an unreachable historical commit, surfacing as "Bad credentials" or a hang in the "Backfilling file list for commit:" stage.

# What?

Adds `bootstrap-sha` to `release-please-config.json`, pinned to the existing `2.0.0` tag's commit (`56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff`). Release Please now only scans commits made after that point, which is everything that could realistically inform the next release.

# Anything else?

`bootstrap-sha` is a one-shot floor, not a moving cursor. Once Release Please has cut at least one release post-setup it tracks the latest through the manifest and tags, and `bootstrap-sha` can be removed later. Leaving it in is harmless either way.