### PR TITLE
fix(ci): move bootstrap-sha to top level of release-please-config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff",
   "packages": {
     ".": {
       "release-type": "node",
       "package-name": "enable-github-automerge-action",
       "include-component-in-tag": false,
       "include-v-in-tag": false,
-      "bootstrap-sha": "56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
# Why?

PR #640 added \`bootstrap-sha\` to bound Release Please's history scan, but I put it under \`packages."."\` where Release Please silently ignores unknown keys. The setting had no effect: the most recent Release Please runs are still backfilling commits back through pre-2.0.0 history (visible in run #26331264500's log walking commits like \`137c6808\` which predate the 2.0.0 tag).

# What?

Moves \`bootstrap-sha\` to the top level of \`release-please-config.json\`, where the schema actually expects it. \`packages.[name].bootstrap-sha\` is not a documented option — it's a Manifest-level setting.

# Anything else?

The next Release Please run should only scan commits made after \`56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff\` (the existing 2.0.0 tag commit), which is a few dozen commits rather than the full repo history.